### PR TITLE
Fix JSON syntax errors in groq downloader notebook

### DIFF
--- a/notebooks/ollama_config/llama3_groq_tool_use_downloader.ipynb
+++ b/notebooks/ollama_config/llama3_groq_tool_use_downloader.ipynb
@@ -72,7 +72,7 @@
       },
       "outputs": [],
       "source": [
-        "        "# Memory optimization functions\n",
+        "# Memory optimization functions\n",
         "import os\n",
         "import shutil\n",
         "import subprocess\n",
@@ -189,7 +189,7 @@
         "show_memory_usage()\n",
         "show_disk_usage()\n",
         "\n",
-        "print(\"\\n\u2705 Optimization complete! Ready to continue.\")""
+        "print(\"\\n\u2705 Optimization complete! Ready to continue.\")"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes JSON syntax errors in the groq downloader notebook that were causing a SyntaxError when parsing the JSON. The following issues were fixed:

1. Removed an extra quote character before the # symbol in a comment (line 75)
2. Removed an extra quote character at the end of a line (line 192)

These changes ensure the notebook is a valid JSON file that can be properly loaded by Jupyter.